### PR TITLE
Improve results display in REPL.

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,8 +32,11 @@ exports.recli = function() {
             }
           });
         } else {
-          var cli = repl.start({prompt: "recli> ",
-                                eval:   misc.replEval});
+          var cli = repl.start({prompt:    "recli> ",
+                                eval:      misc.replEval,
+                                writer:    function(result) {
+                                  return util.inspect(result, {depth: null, colors: true});
+                                } });
           cli.context.r = r;
           cli.context.conn = conn;
           cli.context.db = opts.database;


### PR DESCRIPTION
Results in REPL were printed using the default output method which do not provide unlimited depth traversal. Passing a custom writer to the repl allows to specify an unlimited depth which matches the output provided by non-repl evaluations.
