### PR TITLE
Fix connect options passing.

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,9 +57,9 @@ exports.recli = function() {
     opts = misc.setupOptions(opts, globalSettings, userSettings);
 
     r.connect({
-      host:    opts.host     || 'localhost',
-      port:    opts.port     || 28015,
-      db:      opts.database || 'test',
+      host:    opts.h,
+      port:    opts.p,
+      db:      opts.d,
       authKey: opts.auth
     }, function(err, conn) {
       if (err) {

--- a/lib/misc.js
+++ b/lib/misc.js
@@ -61,6 +61,9 @@ exports.replEval = function(code, context, file, cb) {
 
 exports.setupOptions = function(rawOpts, globalSettings, userSettings) {
   var defaults = {c: false, coffee: false,
+                  d: 'test',
+                  h: 'localhost',
+                  p: 28015,
                   n: false, colors: true,
                   j: false, json: false,
                   r: false, raw: false,
@@ -74,19 +77,19 @@ exports.setupOptions = function(rawOpts, globalSettings, userSettings) {
   opts['$0'] = rawOpts['$0'];
 
   // Override defaults with global settings
-  for (var setting in globalSettings) { 
+  for (var setting in globalSettings) {
     opts[setting] = globalSettings[setting]; 
   }
 
   // Override merged result with user settings
-  for (var setting in userSettings) { 
+  for (var setting in userSettings) {
     opts[setting] = userSettings[setting]; 
   }
 
   // Override merged result with command-line options
-  for (var opt in opts) { 
+  for (var opt in opts) {
     if (rawOpts.hasOwnProperty(opt) && rawOpts[opt] !== opts[opt]) {
-      opts[opt] = rawOpts[opt]; 
+      opts[opt] = rawOpts[opt];
     }
   }
 


### PR DESCRIPTION
It seemes that all options that are not in defaults are completely ignored. In the mean time there was no defaults for connect options in misc.js `defaults`.

Moved connection option defaults, so one can connect to RethinkDB on non-standard addresses.
