### PR TITLE
Make shell more tolerant

### DIFF
--- a/lib/misc.js
+++ b/lib/misc.js
@@ -3,24 +3,26 @@ var vm     = require('vm'),
 
 // Make the rethinkdb result suitable for output
 exports.evalResult = function(conn, result, callback) {
-  result.run(conn, function(err, resultOrCursor) {
-    if (err) {
-      callback(err);
-    } else {
-      if (resultOrCursor) {
-        if (typeof resultOrCursor.toArray === 'function') {
-          resultOrCursor.toArray(function(e, arr) {
-            callback(e, arr);
-          });
-        } else {
-          callback(err, resultOrCursor);
-        }
+  if (typeof result.run === 'function') {
+    result.run(conn, function(err, resultOrCursor) {
+      if (err) {
+        callback(err);
       } else {
-        callback(null, null);
+        if (resultOrCursor) {
+          if (typeof resultOrCursor.toArray === 'function') {
+            resultOrCursor.toArray(callback);
+          } else {
+            callback(err, resultOrCursor);
+          }
+        } else {
+          callback(null, null);
+        }
       }
-    }
-  });
-}
+    });
+  } else {
+    callback(null, result);
+  }
+};
 
 // Custom eval function for the repl module
 exports.replEval = function(code, context, file, cb) {
@@ -28,6 +30,9 @@ exports.replEval = function(code, context, file, cb) {
     cb(null, null);
   } else {
     var err, result, re;
+
+    // we do not need force expression, just because we carefully check syntax later
+    code = code.replace(/^\(/, '').replace(/\)$/, '');
 
     // first, create the Script object to check the syntax
     try {
@@ -40,16 +45,17 @@ exports.replEval = function(code, context, file, cb) {
         displayErrors: false
       });
     } catch (e) {
-      console.log(e);
+      console.log('Script compile error:', e);
       console.log(e.stack);
       return;
     }
 
+    // then, run in context
     if (!err) {
       try {
         re = script.runInContext(context, {displayErrors: false});
       } catch (e) {
-        console.log(e);
+        console.log('Runtime error:', e);
         console.log(e.stack);
         return;
       }
@@ -57,7 +63,7 @@ exports.replEval = function(code, context, file, cb) {
     }
   }
 
-}
+};
 
 exports.setupOptions = function(rawOpts, globalSettings, userSettings) {
   var defaults = {c: false, coffee: false,
@@ -94,7 +100,7 @@ exports.setupOptions = function(rawOpts, globalSettings, userSettings) {
   }
 
   return opts;
-}
+};
 
 exports.usage = function() {
   var usage = '\
@@ -140,4 +146,4 @@ OPTIONAL options:                                                               
 \n';
   console.log(usage);
 
-}
+};


### PR DESCRIPTION
When printing expressions in CLI, I'm putting `;` at the end of it (just out of habit, by usual). But it breaks execution.
The PR allow to have more freedom when writing expressions: it is possible to put `;` at the end of line and also non rethink-query are allowed (they just evaluated as in usual `repl`).
