### PR TITLE
Bumped version to the new rethinkdb.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "recli",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "author": "Stian Grytøyr",
   "description": "RethinkDB CLI query tool and REPL",
   "main": "index.js",
   "preferGlobal": true,
   "dependencies": {
-    "rethinkdb": "1.13.x",
+    "rethinkdb": "1.14.x",
     "optimist": "0.6.x",
     "coffee-script": "1.7.x",
     "js-yaml": "3.0.x",


### PR DESCRIPTION
Hello.
Here is commits for rethinkdb 1.13 and 1.14 versions.
I think it'll be better to have recli version stuck to the rethinkdb version. So you can easily install the right one.
