### PR TITLE
Provide an ND Json writer

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var r      = require('rethinkdb'),
     coffee = require('coffee-script'),
     repl   = require('repl'),
     util   = require('util'),
+    os     = require('os'),
     fs     = require('fs'),
     yaml   = require('js-yaml'),
     misc   = require('./lib/misc'),
@@ -20,12 +21,19 @@ var r      = require('rethinkdb'),
                .alias('json',     'j')
                .alias('port',     'p')
                .alias('raw',      'r')
+               .alias('stream',   's')
                .alias('version',  'v')
                .argv;
 
 var writer = function(rawResult) {
   var result;
-  if (opts.raw) {
+  if (opts.stream) {
+    var i = 0;
+    result = '';
+    for (i in rawResult) {
+      result += JSON.stringify(rawResult[i]) + os.EOL;
+    }
+  } else if (opts.raw) {
     result = JSON.stringify(rawResult);
   } else if (opts.json) {
     result = JSON.stringify(rawResult, null, 2);

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ exports.recli = function() {
         throw err;
       } else {
         if (opts._.length) {
-          var code = opts._[0];
+          var code = opts._.join(' ');
           if (opts.coffee) {
             code = coffee.compile(code, {bare: true});
           }

--- a/lib/misc.js
+++ b/lib/misc.js
@@ -73,6 +73,7 @@ exports.setupOptions = function(rawOpts, globalSettings, userSettings) {
                    colors:   true,
                    json:     false,
                    raw:      false,
+                   stream:   false,
                    version:  false };
 
   if (rawOpts.n) rawOpts.colors = false;
@@ -137,6 +138,9 @@ OPTIONAL options:                                                               
     -n, --no-colors           Do not use colors when pretty-printing.           \n\
                                                                                 \n\
     -p, --port PORT           TCP port to connect to. The default is 28015.     \n\
+                                                                                \n\
+    -s, --stream              Print a line break delimited JSON stream with one \n\
+                              valid JSON object per line.                       \n\
                                                                                 \n\
     -r, --raw                 Print the raw JSON from RethinkDB, with no        \n\
                               formatting applied.                               \n\


### PR DESCRIPTION
This pull request adds a `--stream` writer to output [ndjson](http://ndjson.org) for use with tools like [jq](https://stedolan.github.io/jq/) and [json-stream-formatter](https://npmjs.org/package/json-stream-formatter).

I also updated the command argument parsing to join multiple input arguments allowing you to run queries that contain spaces (i.e. previously running `recli r.table('Foo').pick('bar', 'baz')` would fail because of the space - now it doesn't. Let me know if that should be in a different PR.